### PR TITLE
Clear self._user_attrs when authenticating with user

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -642,6 +642,11 @@ class _LDAPUser(_LDAPConnectionMixIn):
         else:
             user_dn = None
 
+        if self.settings.BIND_AS_AUTHENTICATING_USER:
+            # reset self._user_attrs because the authenticated user may
+            # receive more attributes than the anonymous
+            self._user_attrs = None
+
         return user_dn
 
     def _check_requirements(self):


### PR DESCRIPTION
Some restrictive LDAP installation do not return the full user information in an anonymous session. This patch allows authenticating in this case; the user information if pulled once authenticated.